### PR TITLE
Better changelog and branches management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'CHANGELOG.md'
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ GLOBAL OPTIONS:
    --github-token value              github token [$GITHUB_TOKEN]
    --repo-owner value                repository owner (organization); if not set, we are going to try to guess [$GNSV_REPO_OWNER]
    --repo-name value                 repository name (without owner/organization part); if not set, we are going to try to guess [$GNSV_REPO_NAME]
-   --branch value                    Branch to filter on [$GNSV_BRANCH_NAME]
+   --branches value, --branch value  Coma separated list of branch names to filter on for getting tags and prs (if not set, the default branch is guessed/used) [$GNSV_BRANCH_NAME]
    --consider-also-non-merged-prs    Consider also non-merged PRs (default: false) [$GNSV_CONSIDER_ALSO_NON_MERGED_PRS]
    --tag-regex value                 Regex to match tags (if empty string (default) => no filtering) [$GNSV_TAG_REGEX]
    --ignore-labels value             Coma separated list of PR labels to consider as ignored PRs (OR condition) (default: "Type: Hidden") [$GNSV_HIDDEN_LABELS]
@@ -133,7 +133,7 @@ GLOBAL OPTIONS:
    --github-token value                github token [$GITHUB_TOKEN]
    --repo-owner value                  repository owner (organization); if not set, we are going to try to guess [$GNSV_REPO_OWNER]
    --repo-name value                   repository name (without owner/organization part); if not set, we are going to try to guess [$GNSV_REPO_NAME]
-   --branch value                      Branch to filter on [$GNSV_BRANCH_NAME]
+   --branches value, --branch value    Coma separated list of branch names to filter on for getting tags and prs (if not set, the default branch is guessed/used) [$GNSV_BRANCH_NAME]
    --consider-also-non-merged-prs      Consider also non-merged PRs (default: false) [$GNSV_CONSIDER_ALSO_NON_MERGED_PRS]
    --tag-regex value                   Regex to match tags (if empty string (default) => no filtering) [$GNSV_TAG_REGEX]
    --ignore-labels value               Coma separated list of PR labels to consider as ignored PRs (OR condition) (default: "Type: Hidden") [$GNSV_HIDDEN_LABELS]
@@ -173,7 +173,7 @@ GLOBAL OPTIONS:
    --github-token value              github token [$GITHUB_TOKEN]
    --repo-owner value                repository owner (organization); if not set, we are going to try to guess [$GNSV_REPO_OWNER]
    --repo-name value                 repository name (without owner/organization part); if not set, we are going to try to guess [$GNSV_REPO_NAME]
-   --branch value                    Branch to filter on [$GNSV_BRANCH_NAME]
+   --branches value, --branch value  Coma separated list of branch names to filter on for getting tags and prs (if not set, the default branch is guessed/used) [$GNSV_BRANCH_NAME]
    --consider-also-non-merged-prs    Consider also non-merged PRs (default: false) [$GNSV_CONSIDER_ALSO_NON_MERGED_PRS]
    --tag-regex value                 Regex to match tags (if empty string (default) => no filtering) [$GNSV_TAG_REGEX]
    --ignore-labels value             Coma separated list of PR labels to consider as ignored PRs (OR condition) (default: "Type: Hidden") [$GNSV_HIDDEN_LABELS]
@@ -181,6 +181,7 @@ GLOBAL OPTIONS:
    --minimal-delay-in-seconds value  Minimal delay in seconds between a PR and a tag (if less, we consider that the tag is always AFTER the PR) (default: 5)
    --future                          if set, include a future section (default: false) [$GNSV_CHANGELOG_FUTURE]
    --template-path value             if set, define the path to the changelog template [$GNSV_CHANGELOG_TEMPLATE_PATH]
+   --starting-tag value              if set, defining a starting tag (excluded) for changelog generation, the special value 'LATEST' (combined with --future) will use the latest semantic tag to get only the future section [$GNSV_CHANGELOG_STARTING_TAG]
    --help, -h                        show help
 
 ```

--- a/internal/app/changelog/changelog-default-template.tmpl
+++ b/internal/app/changelog/changelog-default-template.tmpl
@@ -4,10 +4,11 @@
 {{- $deprecated := dict "title" "Deprecated" "match" "one-of-these" "labels" (list "Type: Deprecated" "deprecated") }}
 {{- $removed := dict "title" "Removed" "match" "one-of-these" "labels" (list "Type: Removed" "removed") }}
 {{- $tmpgroups := list $added $fixed $security $deprecated $removed }}
-{{- $alllabels := list "" }}{{ range $group := $tmpgroups }}{{ $alllabels = concat $alllabels $group.labels }}{{ end }}
-{{- $changed := dict "title" "Changed" "match" "none-of-these" "labels" $alllabels }}
+{{- $tmplabels := list "" }}{{ range $group := $tmpgroups }}{{ $tmplabels = concat $tmplabels $group.labels }}{{ end }}
+{{- $changed := dict "title" "Changed" "match" "none-of-these" "labels" $tmplabels }}
 {{- $groups := list $security $added $fixed $deprecated $removed $changed }}
 {{- $reversedSections := .ReversedSections }}
+{{- $branch := .Branch }}
 {{- $repoOwner := .RepoOwner }}
 {{- $repoName := .RepoName -}}
 # CHANGELOG
@@ -33,9 +34,11 @@
 		{{- end }}
 	{{- end }}
 	{{- if lt $i (sub (len $reversedSections) 1) }}
+		{{- $previousSection := index $reversedSections (add $i 1) }}{{ print "\n" }}
 		{{- if $section.Tag }}
-			{{- $previousSection := index $reversedSections (add $i 1) }}{{ print "\n" }}
 <sub>[Full Diff](https://github.com/{{ $repoOwner }}/{{ $repoName }}/compare/{{ $previousSection.Tag.Name }}...{{ $section.Tag.Name }})</sub>
+		{{- else }}
+<sub>[Full Diff](https://github.com/{{ $repoOwner }}/{{ $repoName }}/compare/{{ $previousSection.Tag.Name }}...{{ $branch }})</sub>
 		{{- end }}
 	{{- end }}
 {{ end -}}

--- a/internal/app/changelog/entities.go
+++ b/internal/app/changelog/entities.go
@@ -14,6 +14,7 @@ type Config struct {
 	RepoOwner               string
 	RepoName                string
 	PullRequestIgnoreLabels []string
+	Branch                  string
 }
 
 type Section struct {
@@ -23,6 +24,7 @@ type Section struct {
 
 type Changelog struct {
 	Sections  []*Section
+	Branch    string // Repository branch
 	RepoOwner string // Repository owner name (organization)
 	RepoName  string // Repository name (without owner/organization part)
 }
@@ -132,5 +134,6 @@ func New(tags []*git.Tag, prs []*repo.PullRequest, config Config) *Changelog {
 		RepoOwner: config.RepoOwner,
 		RepoName:  config.RepoName,
 		Sections:  sections,
+		Branch:    config.Branch,
 	}
 }

--- a/internal/app/git/interface.go
+++ b/internal/app/git/interface.go
@@ -5,4 +5,5 @@ type Port interface {
 	// GetContainedTags returns the list of tags contained by the given branch.
 	GetContainedTags(branch string) ([]*Tag, error)
 	GuessGHRepo() (owner string, repo string)
+	GuessDefaultBranch() string
 }

--- a/internal/app/repo/interface.go
+++ b/internal/app/repo/interface.go
@@ -7,6 +7,6 @@ type Port interface {
 	// GetPullRequestsSince returns the list of pull requests since the given date.
 	// If onlyMerged is true, only the merged pull requests since the given date are returned.
 	// If onlyMerged is false, merged pull requests since the given date are returned + (still) open pull requests.
-	GetPullRequestsSince(base string, t time.Time, onlyMerged bool) ([]*PullRequest, error)
+	GetPullRequestsSince(base string, t *time.Time, onlyMerged bool) ([]*PullRequest, error)
 	CreateRelease(base string, tagName string, body string, draft bool) error
 }

--- a/internal/infra/adapters/git/local/local.go
+++ b/internal/infra/adapters/git/local/local.go
@@ -126,6 +126,21 @@ func (r *Adapter) GuessGHRepo() (owner string, repo string) {
 	return extractGHRepoFromRemoteUrl(url)
 }
 
+func (r *Adapter) GuessDefaultBranch() string {
+	logger := slog.Default().With("gitOperation", "guessDefaultBranch")
+	r.cwdOrDie()
+	cmd := exec.Command("git", "remote", "show", "origin")
+	output := r.executeCmdOrDie(logger, cmd)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "HEAD branch:") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmedLine, "HEAD branch:"))
+		}
+	}
+	return ""
+}
+
 func (r *Adapter) GetContainedTags(branch string) ([]*git.Tag, error) {
 	res := []*git.Tag{}
 	r.cwdOrDie()

--- a/internal/infra/adapters/repo/github/github.go
+++ b/internal/infra/adapters/repo/github/github.go
@@ -42,7 +42,7 @@ func NewAdapter(owner string, repo string, opts AdapterOptions) *Adapter {
 	}
 }
 
-func (r *Adapter) getPullRequestsSince(state state, base string, t time.Time) ([]*repo.PullRequest, error) {
+func (r *Adapter) getPullRequestsSince(state state, base string, t *time.Time) ([]*repo.PullRequest, error) {
 	logger := slog.Default().With("base", base, "state", string(state), "since", t)
 	listOptionsState := "open"
 	if state == merged {
@@ -70,13 +70,13 @@ out:
 				continue
 			}
 			if state == "merged" {
-				if pr.UpdatedAt.Before(t) {
+				if t != nil && pr.UpdatedAt.Before(*t) {
 					break out
 				}
 				if pr.MergedAt == nil {
 					continue
 				}
-				if pr.MergedAt.GetTime().Before(t) {
+				if t != nil && pr.MergedAt.GetTime().Before(*t) {
 					continue
 				}
 			}
@@ -111,7 +111,7 @@ out:
 	return res, nil
 }
 
-func (r *Adapter) GetPullRequestsSince(base string, t time.Time, onlyMerged bool) (res []*repo.PullRequest, err error) {
+func (r *Adapter) GetPullRequestsSince(base string, t *time.Time, onlyMerged bool) (res []*repo.PullRequest, err error) {
 	if onlyMerged {
 		return r.getPullRequestsSince(merged, base, t)
 	}

--- a/internal/infra/controllers/cli/create_release.go
+++ b/internal/infra/controllers/cli/create_release.go
@@ -12,11 +12,11 @@ import (
 
 func createReleaseAction(cCtx *cli.Context) error {
 	setDefaultLogger(cCtx)
-	branch := cCtx.String("branch")
 	service, err := getService(cCtx)
 	if err != nil {
 		return err
 	}
+	branches := getBranches(cCtx, service)
 	releaseBodyTemplate := cCtx.String("release-body-template")
 	if cCtx.String("release-body-template-path") != "" {
 		body, err := os.ReadFile(cCtx.String("release-body-template-path"))
@@ -25,7 +25,7 @@ func createReleaseAction(cCtx *cli.Context) error {
 		}
 		releaseBodyTemplate = string(body)
 	}
-	newTag, err := service.CreateNextRelease(branch, !cCtx.Bool("release-force"), cCtx.Bool("release-draft"), releaseBodyTemplate)
+	newTag, err := service.CreateNextRelease(branches, !cCtx.Bool("release-force"), cCtx.Bool("release-draft"), releaseBodyTemplate)
 	if err != nil {
 		if err == app.ErrNoRelease {
 			return cli.Exit(errors.New("no need to create a release => use --release-force if you want to force a version bump and a new release"), 2)

--- a/internal/infra/controllers/cli/next_version.go
+++ b/internal/infra/controllers/cli/next_version.go
@@ -10,12 +10,12 @@ import (
 
 func nextVersionAction(cCtx *cli.Context) error {
 	setDefaultLogger(cCtx)
-	branch := cCtx.String("branch")
 	service, err := getService(cCtx)
 	if err != nil {
 		return err
 	}
-	oldVersion, newVersion, _, err := service.GetNextVersion(branch, !cCtx.Bool("consider-also-non-merged-prs"), cCtx.Bool("dont-increment-if-no-pr"))
+	branches := getBranches(cCtx, service)
+	oldVersion, newVersion, _, err := service.GetNextVersion(branches, !cCtx.Bool("consider-also-non-merged-prs"), cCtx.Bool("dont-increment-if-no-pr"))
 	if err != nil {
 		return cli.Exit(err.Error(), 1)
 	}


### PR DESCRIPTION
- you can specify multiple branches to filter on
- if you don't specify any branch, the main one will be guessed (and we will filter on it)
- you can define a starting tag with `--starting-tag` for changelog